### PR TITLE
refactoring, working split transmission example

### DIFF
--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/io/PythonInputFormat.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/io/PythonInputFormat.java
@@ -18,169 +18,103 @@
 
 package org.apache.flink.python.api.io;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.io.FileInputFormat;
-import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.python.api.streaming.data.PythonStreamer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  */
-public class PythonInputFormat<T extends Tuple> extends FileInputFormat<T> implements ResultTypeQueryable<T> {
-
-	//exclusively needed for executing split logic in python
-	private final PythonStreamer splitStreamer;
-	private PythonStreamer streamer;
-	private boolean streamerOpen;
-	private boolean readForSplit;
-	static final Logger LOG = LoggerFactory.getLogger(PythonInputFormat.class);
+public class PythonInputFormat<T> extends FileInputFormat<T> implements ResultTypeQueryable<T> {
 	private TypeInformation<T> typeInformation;
-	private Path path;
-	private Configuration configuration;
-	private PythonCollector<T> collector;
-	private PythonCollector<String> splitCollector;
-	protected int readRecords = 0;
-	private String filter;
 	private boolean splitsInPython;
 
-	public void setTypeInformation(TypeInformation<T> typeInformation) {
-		this.typeInformation = typeInformation;
-	}
+	private final PythonInputSplitGenerator splitGenerator;
+	private final PythonInputSplitProcessor<T> splitProcessor;
 
 	public PythonInputFormat(Path path, int id, TypeInformation<T> info, String filter, boolean computeSplitsInPython) {
 		super(path);
-		this.path = path;
-		this.filter = filter;
-		this.streamer = new PythonStreamer(this, id);
-		this.splitStreamer = new PythonStreamer(this, id, true);
+		this.splitGenerator = new PythonInputSplitGenerator(id, path, filter);
+		this.splitProcessor = new PythonInputSplitProcessor<>(this, id, info instanceof PrimitiveArrayTypeInfo);
 		this.typeInformation = info;
-		this.collector  = new PythonCollector<T>();
-		this.splitCollector = new PythonCollector<String>();
 		this.splitsInPython = computeSplitsInPython;
 	}
 
+	//==================================================================================================================
+	// Split Generator
+	//==================================================================================================================
+
 	@Override
 	public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
-		if(this.splitsInPython) {
-			//do fancy stuff in python here
-			//TODO: make sure runtime context is not used
-			//TODO: make special methods to execute this part on the JobManager
-			this.splitStreamer.open();
-			//TODO send computation request here
-			//TODO: refactor sendCloseMessage to send Message
-			this.splitStreamer.sendMessage("compute_splits");
-			List<String> pathList = new ArrayList<String>();
-			pathList.add(this.path.toString());
-			this.splitStreamer.streamBufferWithoutGroups(pathList.iterator(), this.splitCollector);
-
-			String[] hosts = {"localhost"};
-			List<FileInputSplit> splits = new ArrayList<FileInputSplit>();
-			int n = 0;
-			while (!this.splitCollector.isEmpty()) {
-				String path = this.splitCollector.poll();
-				System.out.println("ja: received: " + path);
-				splits.add(new FileInputSplit(n, new Path(path), 0, 1, hosts));
-				n++;
-			}
-			return splits.toArray(new FileInputSplit[0]);
-
-			// String path1 = this.splitCollector.poll();
-			// FileInputSplit split1 = new FileInputSplit(0, new Path(path1), 0, 1, new String[]{"localhost"});
-			// String path2 = this.splitCollector.poll();
-			// FileInputSplit split2 = new FileInputSplit(0, new Path(path2), 0, 1, new String[]{"localhost"});
-			// return new FileInputSplit[]{split1, split2};
-		}else {
+		if (this.splitsInPython) {
+			return this.splitGenerator.createInputSplits(numSplits);
+		} else {
 			FileInputSplit[] inputSplits = super.createInputSplits(minNumSplits);
-			System.out.println("break");
 			return inputSplits;
 		}
 	}
 
 	@Override
 	protected boolean acceptFile(FileStatus fileStatus) {
-		String name = fileStatus.getPath().getName();
-		return name.matches(this.filter) && super.acceptFile(fileStatus);
+		return this.splitGenerator.acceptFile(fileStatus) && super.acceptFile(fileStatus);
 	}
 
-	@Override
-	public T nextRecord(T record) throws IOException {
-		if(!readForSplit) {
-			readEnviTile();
-			this.readForSplit = true;
-		}
+	//==================================================================================================================
+	// Split Processor
+	//==================================================================================================================
 
-		if(!this.reachedEnd()) {
-			record = this.collector.poll();
-			this.readRecords++;
-		}else {
-			record = null;
-		}
-		return record;
-	}
-	
 	@Override
 	public void configure(Configuration parameters) {
-		// TODO Auto-generated method stub
 		super.configure(parameters);
-		this.configuration = parameters;
-	}
-
-	private void readEnviTile() throws IOException {
-		List<String> pathList = new ArrayList<String>();
-		pathList.add(this.path.toString());
-		this.streamer.streamBufferWithoutGroups(pathList.iterator(), collector);
+		this.splitProcessor.configure(parameters);
 	}
 
 	@Override
-	public TypeInformation<T> getProducedType() {
-		return this.typeInformation;
+	public void openInputFormat() {
+		super.openInputFormat();
+		try {
+			this.splitProcessor.open();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
-	
+
 	@Override
 	public void open(FileInputSplit split) throws IOException {
-		// TODO Auto-generated method stub
 		super.open(split);
-		this.path = split.getPath();
-		this.readForSplit = false;
-		this.collector.clear();
-		if (!this.streamerOpen) {
-			this.streamer.open();
-			this.streamer.sendMessage("open_task");
-			this.streamer.sendBroadCastVariables(this.configuration);
-			this.streamerOpen = true;
-		}
-
+		this.splitProcessor.openSplit(split);
 	}
 
 	@Override
 	public void close() throws IOException {
 		super.close();
+		this.splitProcessor.closeSplit();
 	}
 
 	@Override
 	public boolean reachedEnd() throws IOException {
-		return this.collector.isEmpty() && this.readForSplit;
+		return this.splitProcessor.reachedEnd();
 	}
 
+	@Override
+	public T nextRecord(T record) throws IOException {
+		return this.splitProcessor.nextRecord(record);
+	}
+
+	@Override
 	public void closeInputFormat() {
-		if(this.streamerOpen) {
-			try {
-				this.streamer.sendMessage("close_streamer");
-				this.streamer.close();
-			}catch (IOException ex) {
-				LOG.error("error closing python IF: " + this.getRuntimeContext().getTaskName() + ": " + ex.getMessage());
-			}
-		}
 		super.closeInputFormat();
+		this.splitProcessor.close();
+	}
+
+	@Override
+	public TypeInformation<T> getProducedType() {
+		return this.typeInformation;
 	}
 }

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/io/PythonInputSplitGenerator.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/io/PythonInputSplitGenerator.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.python.api.io;
+
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.python.api.PythonPlanBinder;
+import org.apache.flink.python.api.streaming.io.PythonSplitGeneratorStreamer;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import static org.apache.flink.python.api.PythonPlanBinder.FLINK_PYTHON_DC_ID;
+
+public class PythonInputSplitGenerator implements Serializable {
+	private final int id;
+	private final Path path;
+	private final String filter;
+	private final String planArguments;
+
+	public PythonInputSplitGenerator(int id, Path path, String filter) {
+		this.id = id;
+		this.path = path;
+		this.filter = filter;
+		this.planArguments = PythonPlanBinder.arguments.toString();
+	}
+
+	public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
+		String tmpPath = System.getProperty("java.io.tmpdir") + "/" + FLINK_PYTHON_DC_ID;
+
+		PythonSplitGeneratorStreamer streamer = new PythonSplitGeneratorStreamer();
+		streamer.open(tmpPath, planArguments, this.id);
+		streamer.sendRecord(minNumSplits);
+		streamer.sendRecord(this.path.toString());
+
+
+		int numSplits = (Integer) streamer.getRecord(true);
+
+		FileInputSplit[] splits = new FileInputSplit[numSplits];
+		for (int x = 0; x < numSplits; x++) {
+			String path = (String) streamer.getRecord();
+			int from = (Integer) streamer.getRecord(true);
+			int to = (Integer) streamer.getRecord(true);
+
+			int numHosts = (Integer) streamer.getRecord(true);
+			String[] hosts = new String[numHosts];
+			for (int y = 0; y < numHosts; y++) {
+				hosts[y] = (String) streamer.getRecord();
+			}
+
+			splits[x] = new FileInputSplit(x, new Path(path), from, to, hosts);
+		}
+		streamer.close();
+		return splits;
+	}
+
+	protected boolean acceptFile(FileStatus fileStatus) {
+		String name = fileStatus.getPath().getName();
+		return name.matches(this.filter);
+	}
+}

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/io/PythonInputSplitProcessor.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/io/PythonInputSplitProcessor.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.python.api.io;
+
+import org.apache.flink.api.common.io.RichInputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.python.api.streaming.io.PythonSplitProcessorStreamer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class PythonInputSplitProcessor<T> implements Serializable {
+	private static final Logger LOG = LoggerFactory.getLogger(PythonInputFormat.class);
+	private final RichInputFormat format;
+	private final int id;
+
+	private Configuration configuration;
+
+	private PythonCollector<T> collector;
+	private PythonSplitProcessorStreamer streamer;
+
+	public PythonInputSplitProcessor(RichInputFormat format, int id, boolean asByteArray) {
+		this.format = format;
+		this.id = id;
+		this.streamer = new PythonSplitProcessorStreamer(format, id, asByteArray);
+	}
+
+	public void configure(Configuration parameters) {
+		this.configuration = parameters;
+	}
+
+	public void open() throws IOException {
+		this.collector = new PythonCollector<>();
+		this.streamer.open();
+		this.streamer.sendBroadCastVariables(this.configuration);
+	}
+
+	public void openSplit(FileInputSplit split) throws IOException {
+		this.streamer.transmitSplit(split);
+	}
+
+	public void closeSplit() {
+	}
+
+	public void close() {
+		try {
+			this.streamer.close();
+		} catch (IOException ex) {
+			LOG.error("error closing python IF: " + format.getRuntimeContext().getTaskName() + ": " + ex.getMessage());
+		}
+	}
+
+	public boolean reachedEnd() throws IOException {
+		if (this.collector.isEmpty()) {
+			return !this.streamer.receiveResults(this.collector);
+		} else {
+			return this.collector.isEmpty();
+		}
+	}
+
+	public T nextRecord(T record) throws IOException {
+		return this.collector.poll();
+	}
+}

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/data/PythonSender.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/data/PythonSender.java
@@ -171,9 +171,6 @@ public class PythonSender<IN> implements Serializable {
 			return new ArraySerializer();
 		}
 
-		if (value instanceof String){
-			return new StringSerializer();
-		}
 		if (((Tuple2) value).f0 instanceof byte[]) {
 			return new ValuePairSerializer();
 		}
@@ -228,18 +225,6 @@ public class PythonSender<IN> implements Serializable {
 				buffer.put((byte[]) value.f0.getField(x));
 			}
 			buffer.put(value.f1);
-		}
-	}
-
-	private class StringSerializer extends Serializer<String> {
-
-		@Override
-		public void serializeInternal(String value) {
-			byte[] bytes = value.getBytes();
-			buffer = ByteBuffer.allocate(bytes.length + 5);
-			buffer.put(TYPE_STRING_VALUE);
-			buffer.putInt(bytes.length);
-			buffer.put(bytes);
 		}
 	}
 }

--- a/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/io/PythonSplitGeneratorStreamer.java
+++ b/flink-libraries/flink-python/src/main/java/org/apache/flink/python/api/streaming/io/PythonSplitGeneratorStreamer.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.python.api.streaming.io;
+
+import org.apache.flink.python.api.streaming.plan.PythonPlanReceiver;
+import org.apache.flink.python.api.streaming.plan.PythonPlanSender;
+import org.apache.flink.python.api.streaming.util.StreamPrinter;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+
+import static org.apache.flink.python.api.PythonPlanBinder.FLINK_PYTHON2_BINARY_PATH;
+import static org.apache.flink.python.api.PythonPlanBinder.FLINK_PYTHON3_BINARY_PATH;
+import static org.apache.flink.python.api.PythonPlanBinder.FLINK_PYTHON_PLAN_NAME;
+import static org.apache.flink.python.api.PythonPlanBinder.usePython3;
+
+public class PythonSplitGeneratorStreamer {
+	protected PythonPlanSender sender;
+	protected PythonPlanReceiver receiver;
+
+	private Process process;
+	private ServerSocket server;
+	private Socket socket;
+
+	public Object getRecord() throws IOException {
+		return getRecord(false);
+	}
+
+	public Object getRecord(boolean normalize) throws IOException {
+		return receiver.getRecord(normalize);
+	}
+
+	public void sendRecord(Object record) throws IOException {
+		sender.sendRecord(record);
+	}
+
+	public void open(String tmpPath, String args, int id) throws IOException {
+		server = new ServerSocket(0);
+		startPython(tmpPath, args, id);
+		socket = server.accept();
+		sender = new PythonPlanSender(socket.getOutputStream());
+		receiver = new PythonPlanReceiver(socket.getInputStream());
+	}
+
+	private void startPython(String tmpPath, String args, int id) throws IOException {
+		String pythonBinaryPath = usePython3 ? FLINK_PYTHON3_BINARY_PATH : FLINK_PYTHON2_BINARY_PATH;
+
+		try {
+			Runtime.getRuntime().exec(pythonBinaryPath);
+		} catch (IOException ex) {
+			throw new RuntimeException(pythonBinaryPath + " does not point to a valid python binary.");
+		}
+		process = Runtime.getRuntime().exec(pythonBinaryPath + " -B " + tmpPath + FLINK_PYTHON_PLAN_NAME + args);
+
+		new StreamPrinter(process.getInputStream()).start();
+		new StreamPrinter(process.getErrorStream()).start();
+
+		try {
+			Thread.sleep(2000);
+		} catch (InterruptedException ex) {
+		}
+
+		try {
+			int value = process.exitValue();
+			if (value != 0) {
+				throw new RuntimeException("Plan file caused an error. Check log-files for details.");
+			}
+			if (value == 0) {
+				throw new RuntimeException("Plan file exited prematurely without an error.");
+			}
+		} catch (IllegalThreadStateException ise) {//Process still running
+		}
+
+		process.getOutputStream().write("splits\n".getBytes());
+		process.getOutputStream().write((server.getLocalPort() + "\n").getBytes());
+		process.getOutputStream().write((id + "\n").getBytes());
+		process.getOutputStream().flush();
+	}
+
+	public void close() {
+		try {
+			process.exitValue();
+		} catch (NullPointerException npe) { //exception occurred before process was started
+		} catch (IllegalThreadStateException ise) { //process still active
+			process.destroy();
+		}
+	}
+}

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/connection/Collector.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/connection/Collector.py
@@ -64,6 +64,32 @@ class PlanCollector(object):
         self._connection.write(b"".join([type, serializer.serialize(value)]))
 
 
+class SplitCollector(object):
+    def __init__(self, con, env):
+        self._connection = con
+        self._env = env
+        self._splits = []
+
+    def _close(self):
+        write = self._write
+        write(len(self._splits))
+        for split in self._splits:
+            write(split.path)
+            write(split.start)
+            write(split.end)
+            write(len(split.hosts))
+            for host in split.hosts:
+                write(host)
+
+    def collect(self, value):
+        self._splits.append(value)
+
+    def _write(self, value):
+        type = _get_type_info(value, self._env._types)
+        serializer = _get_serializer(value, self._env._types)
+        self._connection.write(b"".join([type, serializer.serialize(value)]))
+
+
 #=====Serializer=======================================================================================================
 class Serializer(object):
     def serialize(self, value):

--- a/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/connection/Iterator.py
+++ b/flink-libraries/flink-python/src/main/python/org/apache/flink/python/api/flink/connection/Iterator.py
@@ -190,11 +190,6 @@ class Iterator(defIter.Iterator):
             read = self._read
             if self._deserializer is None:
                 type = read(1)
-                print("Found type: ", type)
-                if type == Types.TYPE_STRING:
-                    print("in string branch")
-                    self._deserializer = StringDeserializer()
-                    return self._deserializer.deserialize(read)
                 if type == Types.TYPE_ARRAY:
                     key_des = _get_deserializer(read, custom_types)
                     self._deserializer = ArrayDeserializer(key_des)


### PR DESCRIPTION
This PR refactors several implementation details and provides a simple working example for a successful split transmission.

List of changes:
- I've refactored the PythonInputFormat into 2 internal components, SplitGenerator and SplitProcessor. This simply makes the whole thing a lot more readable.
-  Revert all changes in PythonSender.java, PythonStreamer.java, Iterator.py
- the python InputFormat class now inherits from Function, this removes a lot of noise in the class

Split Generation:
- The SplitGenerator now uses the PythonPlanSender/-Receiver classes. These are much simpler to use, transmit data over TCP, and allow easy deserialization on the java side. Generally, when all communication with a process is rather small and you want to deserialize stuff in Java, use these classes.
- The Split Generation now has a separate if block within ExecutionEnvironment.execute(), directly calling computeSplits on the format.
- The InputFormat on the python side is supposed to collect a FileInputSplit object; a new collector (SplitCollector) was added to properly handle the transmission
- A new java Streamer class (PythonSplitGeneratorStreamer) was added, only differing to the PythonPlanStreamer in the startPython() method.

Split Processing
- The Split Processingnow has a separate if block within ExecutionEnvironment.execute(), directly searching in the created sources.
- I've added a new java Streamer class (PythonSplitProcessorStreamer). It provides a more easier to use interface to the InputFormat.
- Instead of adding a new sendMessage() method to the streamer i instead submit a null value if the python process is supposed to shut down.

I've modified the WordCount example to use a dummy input format. Note that no code in this PR is just a stand-in or dummy-code,. It also no longer contains envi specific code, whether this is a problem i don't know.

Have a look and feel free to ask any question or comment.
